### PR TITLE
Joint info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ find_package(catkin REQUIRED COMPONENTS
 # Depend on system install of Gazebo
 find_package(gazebo REQUIRED)
 
+add_message_files(
+  FILES
+  JointInfo.msg
+)
+
 add_service_files(
   FILES
   Attach.srv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,8 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.10)
 project(gazebo_ros_link_attacher)
 
-cmake_policy(SET CMP0054 NEW)
-
-#####################################
-## Check c++11 / c++0x support ######
-#####################################
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-  set(CMAKE_CXX_FLAGS "-std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-  set(CMAKE_CXX_FLAGS "-std=c++0x")
-else()
-  message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
-endif()
-#####################################
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS 

--- a/include/gazebo_ros_link_attacher.h
+++ b/include/gazebo_ros_link_attacher.h
@@ -22,6 +22,7 @@
 #include "gazebo_ros_link_attacher/Attach.h"
 #include "gazebo_ros_link_attacher/AttachRequest.h"
 #include "gazebo_ros_link_attacher/AttachResponse.h"
+#include "gazebo_ros_link_attacher/JointInfo.h"
 
 namespace gazebo
 {
@@ -40,7 +41,8 @@ namespace gazebo
 
         /// \brief Attach with a revolute joint
         bool attach(std::string model1, std::string link1,
-                    std::string model2, std::string link2);
+                    std::string model2, std::string link2,
+                    const gazebo_ros_link_attacher::JointInfo& joint_info);
 
         /// \brief Detach
         bool detach(std::string model1, std::string link1,

--- a/msg/JointInfo.msg
+++ b/msg/JointInfo.msg
@@ -1,0 +1,4 @@
+string type
+uint8 axis
+float32 upper_limit
+float32 lower_limit

--- a/srv/Attach.srv
+++ b/srv/Attach.srv
@@ -2,5 +2,6 @@ string model_name_1
 string link_name_1
 string model_name_2
 string link_name_2
+gazebo_ros_link_attacher/JointInfo[] joint_info # optional
 ---
 bool ok


### PR DESCRIPTION
# Description
Adding a new message JointInfo (optional in service).
We can specify the type of joint and limits this way.

# Test
```
rosservice call /link_attacher_node/attach "model_name_1: 'amr1'
link_name_1: 'fork_link'
model_name_2: 'chariot'
link_name_2: 'pivot'
joint_info:
- {type: 'revolute', axis: 2, upper_limit: 1.57, lower_limit: -1.57}" 
```

https://user-images.githubusercontent.com/6097267/153481341-b825e0b2-4c77-4223-94bb-ac3101c0e595.mp4


