### PR TITLE
add name and state publisher for new attached joints

### DIFF
--- a/include/gazebo_ros_link_attacher.h
+++ b/include/gazebo_ros_link_attacher.h
@@ -8,6 +8,7 @@
 #define GAZEBO_ROS_LINK_ATTACHER_HH
 
 #include <ros/ros.h>
+#include <sensor_msgs/JointState.h>
 
 #include <sdf/sdf.hh>
 #include "gazebo/gazebo.hh"
@@ -69,6 +70,8 @@ namespace gazebo
         ros::NodeHandle nh_;
         ros::ServiceServer attach_service_;
         ros::ServiceServer detach_service_;
+        sensor_msgs::JointState joint_state_;
+        ros::Publisher joint_state_pub_;
 
         bool attach_callback(gazebo_ros_link_attacher::Attach::Request &req,
                               gazebo_ros_link_attacher::Attach::Response &res);

--- a/include/gazebo_ros_link_attacher.h
+++ b/include/gazebo_ros_link_attacher.h
@@ -70,7 +70,6 @@ namespace gazebo
         ros::NodeHandle nh_;
         ros::ServiceServer attach_service_;
         ros::ServiceServer detach_service_;
-        sensor_msgs::JointState joint_state_;
         ros::Publisher joint_state_pub_;
 
         bool attach_callback(gazebo_ros_link_attacher::Attach::Request &req,

--- a/src/gazebo_ros_link_attacher.cpp
+++ b/src/gazebo_ros_link_attacher.cpp
@@ -258,14 +258,14 @@ namespace gazebo
       detach_vector.clear();
     }
 
-    joint_state_ = sensor_msgs::JointState();
-    for (const auto& joint : joints) {
-      joint_state_.name.push_back(joint.joint->GetName());
-      joint_state_.position.push_back(joint.joint->Position());
-      joint_state_.velocity.push_back(joint.joint->GetVelocity(0));
-    }
-    if (!joint_state_.name.empty() && joint_state_pub_.getNumSubscribers() > 0) {
-      joint_state_pub_.publish(joint_state_);
+    if (joint_state_pub_.getNumSubscribers() > 0) {
+      sensor_msgs::JointState joint_state;
+      for (const auto& joint : joints) {
+        joint_state.name.push_back(joint.joint->GetName());
+        joint_state.position.push_back(joint.joint->Position());
+        joint_state.velocity.push_back(joint.joint->GetVelocity(0));
+      }
+      joint_state_pub_.publish(joint_state);
     }
   }
 


### PR DESCRIPTION
Since now we have revolute joints, it is useful to know the joint position state (e.g. for towing)