### PR TITLE
Remove gazebo link directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS 
-  roscpp 
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
   gazebo_ros
   geometry_msgs
   std_msgs
@@ -46,7 +46,6 @@ catkin_package(CATKIN_DEPENDS message_runtime)
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(include)
-link_directories(${GAZEBO_LIBRARY_DIRS})
 include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS})
 
 ## Declare a cpp library
@@ -54,7 +53,8 @@ add_library(${PROJECT_NAME} src/gazebo_ros_link_attacher.cpp)
 
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} )
+
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS})
 
 


### PR DESCRIPTION
This change removes unneeded includes.
It helps to remove dependencies that cause conflicts with other versions of protobuf.

Tested io_amr CI with these changes https://github.com/rapyuta-robotics/rr_io_amr/pull/2326